### PR TITLE
Update the the "UXDFS protocol"

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -48,6 +48,8 @@
 #include "md5.h"
 #include "m_perfstats.h"
 
+#include "speedrun.h"
+
 // aaaaaa
 #include "i_joy.h"
 
@@ -3863,6 +3865,7 @@ static void Got_AddPlayer(UINT8 **p, INT32 playernum)
 		}
 
 		HU_AddChatText(joinmsg, false);
+		send_best_time();
 	}
 
 	if (server && multiplayer && motd[0] != '\0')

--- a/src/luascripts/highscore_show.lua
+++ b/src/luascripts/highscore_show.lua
@@ -1,37 +1,42 @@
-local username = {}
-local skin = {}
-local time = {}
-local full_rows = 0
-local used_row = 0
-local no_time = true
+--Script by Meziu & LeonardoTheMutant
 
-local function receive_data(source, type, target, msg)
-	if msg:sub(0, 5) == "UXDFS"
-		local data_msg = msg:sub(6)
+local username, skin, time, time_str, recieved_row, used_row, got_time
+
+local function SCTCL_ResetBuffer()
+	username = {} --username (string)
+	skin = {} --skin (string)
+	time = {} --time (integer, tics value)
+	time_str = {} --time (string, tics value converted to mm:ss.cc)
+	recieved_row = 0 --the row number being currently procecced by the reciever
+	used_row = -1 --row used by the current player
+end
+
+--
+-- The "SCTCL" reciever
+-- ("Server C To Client Lua")
+--
+addHook("PlayerMsg", function(s, t, r, m) --source, type, reciever (target), message
+	if (m:sub(0, 6) == "#SCTCL") --'#' to make it more rare for players to accidentaly type in a conversation
+		if (used_row != -1) then SCTCL_ResetBuffer() end --if the data is being sent again clear the buffer first
+
+		local data_msg = m:sub(7)
 		
-		full_rows = full_rows + 1
+		recieved_row = $ + 1
 		
 		local first_comma = data_msg:find(",")
-		local second_comma = data_msg:find(",", first_comma+1)
+		local second_comma = data_msg:find(",", (first_comma + 1))
+		local third_comma = data_msg:find(",", (second_comma + 1))
 		
-		username[full_rows] = data_msg:sub(0, first_comma-1)
-		skin[full_rows] = data_msg:sub(first_comma+1, second_comma-1)
-		time[full_rows] = data_msg:sub(second_comma+1)
+		username[recieved_row] = data_msg:sub(0, (first_comma - 1))
+		skin[recieved_row] = data_msg:sub((first_comma + 1), (second_comma-1))
+		time[recieved_row] = data_msg:sub((second_comma + 1), (third_comma-1)) --make sure you always check this variable for NIL!
+		time_str[recieved_row] = data_msg:sub(third_comma + 1)
 		return true
 	end
-end
-addHook("PlayerMsg", receive_data)
+end)
 
-
-local function reset_on_map_change(mapnum)
-	username = {}
-	skin = {}
-	time = {}
-	full_rows = 0
-	used_row = 0
-end
-addHook("MapLoad", reset_on_map_change)
-
+addHook("MapLoad", SCTCL_ResetBuffer)
+addHook("PlayerJoin", SCTCL_ResetBuffer)
 
 local function find_in_array(array, value)
 	for k, v in ipairs(array) do
@@ -42,28 +47,21 @@ local function find_in_array(array, value)
 	return -1
 end
 
-
-local function check_player_skin(player)
-	if player == displayplayer
-		used_row = find_in_array(skin, player.mo.skin)
-		
-		if used_row == -1
-			no_time = true
-		else
-			no_time = false
-		end
+addHook("PlayerThink", function(p) --player
+	if (p.mo) and (p.mo.valid) and (skin)
+		used_row = find_in_array(skin, p.mo.skin)
 	end
-end
-addHook("PlayerThink", check_player_skin)
+end)
 
 
 local function show_score(v)
-	if no_time
+	if (used_row != -1) --there is data suitable for us (the player)
+		v.drawString(4, 176, "BEST TIME FOR "..string.upper(skin[used_row])..":", 45056)
+		v.drawString(4, 184, time_str[used_row].." by "+username[used_row])
+		--server also sends the time value in tics in case you need
+		v.drawString(160, 184, "("..time[used_row].." tics)")
+	else --we got no data for us
 		v.drawString(4, 173, "NO BEST TIME YET, BE FIRST TO FINISH!", 45056)
-	else
-		v.drawString(4, 173, "BEST TIME FOR " + string.upper(skin[used_row]) + ":", 45056)
-		v.drawString(4, 182, time[used_row]+" by "+username[used_row])
 	end
-	
 end
 hud.add(show_score, "scores")

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -7942,8 +7942,8 @@ boolean P_LoadLevel(boolean fromnetsave, boolean reloadinggamestate)
 
 		P_MapStart(); // just in case MapLoad modifies tmthing
 
-		send_best_time();
 		LUA_HookInt(gamemap, HOOK(MapLoad));
+		send_best_time();
 		
 		P_MapEnd(); // just in case MapLoad modifies tmthing
 	}

--- a/src/speedrun.h
+++ b/src/speedrun.h
@@ -34,7 +34,6 @@ char *time_to_string(int time);
 void insert_score(MYSQL *con, int mapnum, char* username, char* skin, int time);
 void insert_map(MYSQL *con, int mapnum, char *mapname);
 void process_time(MYSQL *con, int playernum, int mapnum);
-void speedrun_map_completed();
 void init_string(struct string *s);
 size_t write_to_string(void *ptr, size_t size, size_t nmemb, struct string *s);
 void add_message(char *msg);


### PR DESCRIPTION
Newly joined players would not receive the "Best time" data from the server, because it is sent only during the level load (before the "MapLoad" LUA hook is executed). This commit solves this problem by sending the "Best time" when "PlayerJoin" LUA hook runs. I additionally made the server send the original time value in tics, in case Client-side LUA needs to perform precise time calculations

The [client-side LUA](src/luascripts/highscore_show.lua) (the "reciever") is also updated to reflect the changes on the Server-side